### PR TITLE
Add display format type (simple/csv/table)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,6 +20,18 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
+  version = "v0.0.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/olekukonko/tablewriter"
+  packages = ["."]
+  revision = "b8a9be070da40449e501c3c4730a889e42d87a9e"
+
+[[projects]]
   branch = "master"
   name = "github.com/sclevine/agouti"
   packages = [".","api","api/internal/bus","api/internal/service","internal/element","internal/target"]
@@ -35,6 +47,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3731e98647559bcb54ddfdec0d57d569417cf6aaa2333d0b3922fea128a79ce"
+  inputs-digest = "56701fa25f7e2c300e757f36c2a3f24c0a8f96674956d3b61c4d940c58a8972f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ netflix-activities \
     -data PATH  \        # Set data file path (default: viewing_history.json)
     -limit NUM  \        # Set amount of displaying viewing history (default: 10)
     -expire NUM \        # Set amount of minutes keeping viewing history before you get (default: 60)
+    -format TYPE \       # Set display type (simple/csv/table. default: simple)
 ```
 
 you can also display version and usage:

--- a/main.go
+++ b/main.go
@@ -12,21 +12,31 @@ var (
 	Revision string
 )
 
+var (
+	c = flag.String("conf", "settings.toml", "configuration file path")
+	d = flag.String("data", "viewing_history.json", "viewing history data file path")
+	l = flag.Int("limit", 10, "viewing history display record number limit")
+	e = flag.Int("expire", 60, "viewing history expire duration (minutes)")
+	f = flag.String("format", "simple", "print format(simple/csv/table. default: simple)")
+	v = flag.Bool("version", false, "print version")
+	h = flag.Bool("help", false, "print usage")
+)
+
 func printVersion() {
 	fmt.Printf("version: %s(%s)\n", Version, Revision)
 }
 
-func run(configPath string, dataPath string, limit int, expire int, w io.Writer) (int) {
+func run(w io.Writer) (int) {
 	config := &Config{}
-	if err := config.Read(configPath); err != nil {
+	if err := config.Read(*c); err != nil {
 		fmt.Printf("failed to read config:%v\n", err)
 		return 1
 	}
 
 	vh := &ViewingHistory{}
-	filePath := dataPath
+	filePath := *d
 
-	if vh.ExistData(filePath) && !vh.Expire(filePath, expire) {
+	if vh.ExistData(filePath) && !vh.Expire(filePath, *e) {
 		if err := vh.LoadFromFile(filePath); err != nil {
 			fmt.Printf("failed to parse viewing history(local):%v\n", err)
 			return 1
@@ -53,19 +63,11 @@ func run(configPath string, dataPath string, limit int, expire int, w io.Writer)
 		fmt.Printf("failed to save viewing history:%v\n", err)
 	}
 
-	vh.Print(limit, "tsv", w)
+	vh.Print(*l, *f, w)
 	return 0
 }
 
 func main() {
-	var (
-		c = flag.String("conf", "settings.toml", "configuration file path")
-		d = flag.String("data", "viewing_history.json", "viewing history data file path")
-		l = flag.Int("limit", 10, "viewing history display record number limit")
-		e = flag.Int("expire", 60, "viewing history expire duration (minutes)")
-		v = flag.Bool("version", false, "print version")
-		h = flag.Bool("help", false, "print usage")
-	)
 	flag.Parse()
 
 	if *v {
@@ -79,6 +81,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	ret := run(*c, *d, *l, *e, os.Stdout)
+	ret := run(os.Stdout)
 	os.Exit(ret)
 }

--- a/viewing_history.go
+++ b/viewing_history.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"bytes"
+	"github.com/olekukonko/tablewriter"
+	"encoding/csv"
 )
 
 var dateLayout = "2006/01/02"
@@ -101,7 +103,15 @@ func (vh *ViewingHistory) SaveData(path string) (error) {
 	return nil
 }
 
-func (vh *ViewingHistory) Print(limit int, displayType string, w io.Writer) {
+func (vh *ViewingHistory) Print(limit int, fromat string, w io.Writer) {
+	switch fromat {
+	case "csv": vh.CsvPrint(limit, w);
+	case "table": vh.TablePrint(limit, w);
+	default: vh.SimplePrint(limit, w)
+	}
+}
+
+func (vh *ViewingHistory) SimplePrint(limit int, w io.Writer) {
 	for i, r := range vh.Records {
 		if i > limit - 1 {
 			break
@@ -109,4 +119,35 @@ func (vh *ViewingHistory) Print(limit int, displayType string, w io.Writer) {
 
 		fmt.Fprintf(w, "%s\t%s\n", r.Date.Format(dateLayout), r.Title)
 	}
+}
+
+func (vh *ViewingHistory) CsvPrint(limit int, w io.Writer) {
+	writer := csv.NewWriter(w)
+	writer.UseCRLF = true
+	writer.Write([]string {"view_date", "video_title"})
+
+	for i, r := range vh.Records {
+		if i > limit - 1 {
+			break
+		}
+
+		writer.Write([]string {r.Date.Format(dateLayout), r.Title})
+	}
+
+	writer.Flush()
+}
+
+func (vh *ViewingHistory) TablePrint(limit int, w io.Writer) {
+	writer := tablewriter.NewWriter(w)
+	writer.SetHeader([]string{"view_date", "video_title"})
+
+	for i, r := range vh.Records {
+		if i > limit - 1 {
+			break
+		}
+
+		writer.Append([]string {r.Date.Format(dateLayout), r.Title})
+	}
+
+	writer.Render()
 }


### PR DESCRIPTION
Add display format type (simple/csv/table) with `-f` command line option.

Followings are samples.

* simple

No header and separate with tab.

```
2018/02/26     私立探偵ダーク・ジェントリー: シーズン1: もっと強引に
...
```

* csv

CSV using `encoding/csv`

```output.csv
view_date,video_title
2018/02/26,私立探偵ダーク・ジェントリー: シーズン1: もっと強引に
...
```

* table

Table using [olekukonko/tablewriter](github.com/olekukonko/tablewriter)

```
+------------+--------------------------------+
| VIEW DATE  |          VIDEO TITLE           |
+------------+--------------------------------+
| 2018/02/26 | 私立探偵ダーク・ジェントリー:  |
|            | シーズン1: もっと強引に        |
...
+------------+--------------------------------+
```